### PR TITLE
Fix table 'roles' doesn't exist -> Add spatie-permission vendor:publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ if you haven't done so yet.
 ```bash
 php artisan vendor:publish --tag="filament-access-control-migrations"
 php artisan vendor:publish --tag="filament-access-control-config"
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider"
 php artisan migrate
 ```
 


### PR DESCRIPTION
If you don't add this provider, the apps throws an error because spatie tables like roles or permissions does not exists